### PR TITLE
fix(deb): replace systemd service symlink with real file

### DIFF
--- a/halpid/debian/halpid.service
+++ b/halpid/debian/halpid.service
@@ -1,1 +1,24 @@
-../../systemd/halpid.service
+[Unit]
+Description=HALPI2 Power Monitoring and Watchdog Daemon
+Documentation=https://docs.hatlabs.fi/halpi2
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/halpid
+Restart=on-failure
+RestartSec=10
+User=root
+Environment=RUST_LOG=info
+StandardOutput=journal
+StandardError=journal
+
+# Security hardening (optional but recommended)
+# These can be uncommented for additional security
+# ProtectSystem=strict
+# ProtectHome=true
+# PrivateTmp=true
+# NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- Replaced `halpid/debian/halpid.service` symlink with real file copy
- Eliminates cargo-deb warning about "No usable systemd units found"

## Details

The symlink approach caused cargo-deb to emit a warning during package build:
```
No usable systemd units found for halpid in /workspace/halpid/debian/
```

By copying the file directly to `halpid/debian/`, cargo-deb can properly:
- Detect the systemd unit file
- Manage systemd integration (enable/disable/restart)
- Handle package install/upgrade/removal correctly

The service file content is unchanged - this is purely a packaging fix.

## Test plan
- [ ] Build Debian package with `./run package:deb:docker`
- [ ] Verify no cargo-deb warning about systemd units
- [ ] Install package and verify systemd service works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)