### PR TITLE
fix(ci): attach assets during draft creation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,12 +116,13 @@ jobs:
           else
             .github/scripts/generate-release-notes.sh "${VERSION}" "${VERSION}" draft
 
-            echo "📋 Creating draft release v${VERSION}"
+            echo "📋 Creating draft release v${VERSION} with .deb package"
             gh release create "v${VERSION}" \
               --draft \
               --title "v${VERSION}" \
-              --notes-file release_notes.md
-            echo "✅ Draft release created successfully"
+              --notes-file release_notes.md \
+              *.deb
+            echo "✅ Draft release created successfully with .deb attached"
           fi
         env:
           GH_TOKEN: ${{ github.token }}
@@ -151,6 +152,6 @@ jobs:
           echo "Release tag: v${TAG_VERSION}"
           echo "Release URL: https://github.com/${{ github.repository }}/releases/tag/v${TAG_VERSION}"
           echo ""
-          echo "✅ Pre-release created"
-          echo "✅ Draft release created"
+          echo "✅ Pre-release created with .deb package"
+          echo "✅ Draft release created with .deb attached"
           echo "✅ Dispatched to apt.hatlabs.fi unstable channel"


### PR DESCRIPTION
## Summary

- main.yml: Attach .deb to draft stable release during creation

This ensures assets are always present when a release is published.
The release.yml already has asset verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)