### PR TITLE
refactor(ci): adapt pr-main-release workflow from cockpit-apt

### DIFF
--- a/.github/actions/build-deb/action.yml
+++ b/.github/actions/build-deb/action.yml
@@ -1,5 +1,5 @@
 name: 'Build Debian Package'
-description: 'Build Rust daemon and create .deb package'
+description: 'Build Rust daemon and create .deb package using cargo-deb'
 
 runs:
   using: 'composite'
@@ -16,20 +16,26 @@ runs:
       with:
         key: aarch64-unknown-linux-musl
 
+    - name: Install cargo-deb
+      run: cargo install cargo-deb
+      shell: bash
+
     - name: Build for aarch64
       run: cargo build --release --target aarch64-unknown-linux-musl
       shell: bash
 
-    - name: Install dpkg-dev
-      run: sudo apt-get update && sudo apt-get install -y dpkg-dev
-      shell: bash
+    - name: Build Debian package with cargo-deb
+      run: |
+        # Build the halpi CLI tool as well (referenced in Cargo.toml assets)
+        cargo build --release --target aarch64-unknown-linux-musl -p halpi
 
-    - name: Build Debian package
-      run: dpkg-buildpackage -b -uc -us
+        # Build the .deb package
+        cargo deb -p halpid --target aarch64-unknown-linux-musl --no-build
       shell: bash
 
     - name: Move package to root
-      run: mv ../halpi2-rust-daemon_*.deb ./
+      run: |
+        mv target/aarch64-unknown-linux-musl/debian/*.deb ./
       shell: bash
 
     - name: List generated packages

--- a/.github/scripts/calculate-revision.sh
+++ b/.github/scripts/calculate-revision.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -euo pipefail
+
+# Calculate the next revision number for a given upstream version
+# Usage: calculate-revision.sh <upstream-version>
+# Example: calculate-revision.sh 5.0.0
+#
+# Finds all git tags matching v<upstream-version>+<N> or v<upstream-version>+<N>_pre
+# Returns the next N value (highest N + 1)
+# Returns 1 if no matching tags exist
+
+UPSTREAM_VERSION="${1:-}"
+
+if [ -z "$UPSTREAM_VERSION" ]; then
+    echo "Error: upstream version required" >&2
+    echo "Usage: $0 <upstream-version>" >&2
+    exit 1
+fi
+
+# Remove 'v' prefix if present
+UPSTREAM_VERSION="${UPSTREAM_VERSION#v}"
+
+# Find all tags matching the pattern: v{version}+{N} or v{version}+{N}_pre
+# Pattern: v5.0.0+1, v5.0.0+1_pre, v5.0.0+2, etc.
+PATTERN="v${UPSTREAM_VERSION}+*"
+
+# Get all matching tags
+MATCHING_TAGS=$(git tag -l "$PATTERN" 2>/dev/null || true)
+
+if [ -z "$MATCHING_TAGS" ]; then
+    # No matching tags, this is the first build
+    echo "1"
+    exit 0
+fi
+
+# Extract revision numbers from tags
+# Example: v5.0.0+2_pre -> 2, v5.0.0+3 -> 3
+MAX_REVISION=0
+while IFS= read -r tag; do
+    # Extract the number between '+' and either end of string or '_'
+    # Pattern: v5.0.0+N or v5.0.0+N_pre
+    if [[ $tag =~ \+([0-9]+)(_.*)?$ ]]; then
+        REVISION="${BASH_REMATCH[1]}"
+        if [ "$REVISION" -gt "$MAX_REVISION" ]; then
+            MAX_REVISION="$REVISION"
+        fi
+    fi
+done <<< "$MATCHING_TAGS"
+
+# Return next revision number
+NEXT_REVISION=$((MAX_REVISION + 1))
+echo "$NEXT_REVISION"

--- a/.github/scripts/read-version.sh
+++ b/.github/scripts/read-version.sh
@@ -1,13 +1,10 @@
 #!/bin/bash
 # Read version from VERSION file
-# Sets version and tag_version in GitHub output
+# Sets upstream version in GitHub output
 
 set -e
 
-VERSION=$(cat VERSION | tr -d '\n\r ')
-# For daemon, version and tag_version are the same
-TAG_VERSION="$VERSION"
+UPSTREAM_VERSION=$(cat VERSION | tr -d '\n\r ')
 
-echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-echo "tag_version=$TAG_VERSION" >> "$GITHUB_OUTPUT"
-echo "Version from VERSION file: $VERSION (tag version: $TAG_VERSION)"
+echo "upstream=$UPSTREAM_VERSION" >> "$GITHUB_OUTPUT"
+echo "Upstream version: $UPSTREAM_VERSION"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,13 +30,49 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Read version from Cargo.toml
+      - name: Read version from VERSION file
         id: version
-        run: .github/scripts/read-version.sh
+        run: |
+          UPSTREAM_VERSION=$(cat VERSION)
+          echo "upstream=$UPSTREAM_VERSION" >> $GITHUB_OUTPUT
+          echo "Upstream version: $UPSTREAM_VERSION"
 
-      - name: Check if published release exists
+      - name: Calculate revision number
+        id: revision
+        run: |
+          chmod +x .github/scripts/calculate-revision.sh
+          REVISION=$(.github/scripts/calculate-revision.sh "${{ steps.version.outputs.upstream }}")
+          echo "revision=$REVISION" >> $GITHUB_OUTPUT
+          echo "Revision number: $REVISION"
+
+      - name: Set version variables
+        id: versions
+        run: |
+          UPSTREAM="${{ steps.version.outputs.upstream }}"
+          REVISION="${{ steps.revision.outputs.revision }}"
+          DEBIAN_VERSION="${UPSTREAM}-${REVISION}"
+          PRERELEASE_TAG="v${UPSTREAM}+${REVISION}_pre"
+          STABLE_TAG="v${UPSTREAM}+${REVISION}"
+
+          echo "debian_version=$DEBIAN_VERSION" >> $GITHUB_OUTPUT
+          echo "prerelease_tag=$PRERELEASE_TAG" >> $GITHUB_OUTPUT
+          echo "stable_tag=$STABLE_TAG" >> $GITHUB_OUTPUT
+
+          echo "Debian version: $DEBIAN_VERSION"
+          echo "Pre-release tag: $PRERELEASE_TAG"
+          echo "Stable tag: $STABLE_TAG"
+
+      - name: Check if pre-release exists
         id: check
-        run: .github/scripts/check-release-exists.sh "${{ steps.version.outputs.version }}" prerelease
+        run: |
+          TAG="${{ steps.versions.outputs.prerelease_tag }}"
+          if gh release view "$TAG" &>/dev/null; then
+            echo "action=skip" >> $GITHUB_OUTPUT
+            echo "Pre-release $TAG already exists, skipping"
+          else
+            echo "action=create" >> $GITHUB_OUTPUT
+            echo "Pre-release $TAG does not exist, will create"
+          fi
         env:
           GH_TOKEN: ${{ github.token }}
 
@@ -47,9 +83,10 @@ jobs:
       - name: Rename package with distro+component suffix
         if: steps.check.outputs.action == 'create'
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          OLD_NAME="halpi2-rust-daemon_${VERSION}_amd64.deb"
-          NEW_NAME="halpi2-rust-daemon_${VERSION}_amd64+${APT_DISTRO}+${APT_COMPONENT}.deb"
+          UPSTREAM="${{ steps.version.outputs.upstream }}"
+          # cargo-deb uses the upstream version directly
+          OLD_NAME="halpid_${UPSTREAM}_arm64.deb"
+          NEW_NAME="halpid_${UPSTREAM}_arm64+${APT_DISTRO}+${APT_COMPONENT}.deb"
 
           if [ -f "$OLD_NAME" ]; then
             echo "📦 Renaming package: $(basename $OLD_NAME) → $(basename $NEW_NAME)"
@@ -58,70 +95,61 @@ jobs:
             echo "Package location: $NEW_NAME"
           else
             echo "❌ Error: Expected package not found: $OLD_NAME"
+            echo "Available .deb files:"
+            ls -la *.deb 2>/dev/null || echo "No .deb files found"
             exit 1
           fi
 
-      - name: Generate release notes
+      - name: Generate pre-release notes
         if: steps.check.outputs.action == 'create'
         id: notes
-        run: .github/scripts/generate-release-notes.sh "${{ steps.version.outputs.version }}" "${{ steps.version.outputs.tag_version }}" prerelease
-        env:
-          GH_TOKEN: ${{ github.token }}
-
-      - name: Delete existing pre-release
-        if: steps.check.outputs.action == 'create'
         run: |
-          TAG_VERSION="${{ steps.version.outputs.tag_version }}"
-          if gh release view "v${TAG_VERSION}" &>/dev/null; then
-            IS_PRERELEASE=$(gh release view "v${TAG_VERSION}" --json isPrerelease --jq '.isPrerelease')
-            if [ "$IS_PRERELEASE" = "true" ]; then
-              echo "🗑️  Deleting existing pre-release v${TAG_VERSION}"
-              gh release delete "v${TAG_VERSION}" --yes --cleanup-tag
-            fi
-          fi
+          chmod +x .github/scripts/generate-release-notes.sh
+          .github/scripts/generate-release-notes.sh \
+            "${{ steps.versions.outputs.debian_version }}" \
+            "${{ steps.versions.outputs.prerelease_tag }}" \
+            prerelease
         env:
           GH_TOKEN: ${{ github.token }}
 
       - name: Create pre-release
         if: steps.check.outputs.action == 'create'
         run: |
-          TAG_VERSION="${{ steps.version.outputs.tag_version }}"
+          PRERELEASE_TAG="${{ steps.versions.outputs.prerelease_tag }}"
           if ! ls *.deb 1> /dev/null 2>&1; then
             echo "❌ Error: No .deb files found"
             exit 1
           fi
-          echo "📦 Creating pre-release v${TAG_VERSION}"
-          gh release create "v${TAG_VERSION}" \
+          echo "📦 Creating pre-release $PRERELEASE_TAG"
+          gh release create "$PRERELEASE_TAG" \
             --prerelease \
-            --title "v${TAG_VERSION} (Pre-release)" \
+            --title "$PRERELEASE_TAG (Pre-release)" \
             --notes-file release_notes.md \
             *.deb
           echo "✅ Pre-release created successfully"
         env:
           GH_TOKEN: ${{ github.token }}
 
-      - name: Create draft release
+      - name: Create draft stable release
         if: steps.check.outputs.action == 'create'
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          TAG_VERSION="${{ steps.version.outputs.tag_version }}"
+          STABLE_TAG="${{ steps.versions.outputs.stable_tag }}"
+          DEBIAN_VERSION="${{ steps.versions.outputs.debian_version }}"
 
-          if gh release view "v${VERSION}" &>/dev/null; then
-            IS_DRAFT=$(gh release view "v${VERSION}" --json isDraft --jq '.isDraft')
-            IS_PRERELEASE=$(gh release view "v${VERSION}" --json isPrerelease --jq '.isPrerelease')
-
-            if [ "$IS_DRAFT" = "true" ] && [ "$IS_PRERELEASE" = "false" ]; then
-              echo "Draft release v${VERSION} already exists, skipping creation"
-            fi
+          # Check if stable release already exists
+          if gh release view "$STABLE_TAG" &>/dev/null; then
+            echo "Release $STABLE_TAG already exists, skipping creation"
           else
-            .github/scripts/generate-release-notes.sh "${VERSION}" "${VERSION}" draft
+            # Generate release notes for draft
+            .github/scripts/generate-release-notes.sh "$DEBIAN_VERSION" "$STABLE_TAG" draft
 
-            echo "📋 Creating draft release v${VERSION}"
-            gh release create "v${VERSION}" \
+            echo "📋 Creating draft release $STABLE_TAG with .deb package"
+            gh release create "$STABLE_TAG" \
               --draft \
-              --title "v${VERSION}" \
-              --notes-file release_notes.md
-            echo "✅ Draft release created successfully"
+              --title "$STABLE_TAG" \
+              --notes-file release_notes.md \
+              *.deb
+            echo "✅ Draft release created successfully with .deb attached"
           fi
         env:
           GH_TOKEN: ${{ github.token }}
@@ -144,13 +172,21 @@ jobs:
       - name: Report success
         if: steps.check.outputs.action == 'create'
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          TAG_VERSION="${{ steps.version.outputs.tag_version }}"
+          DEBIAN_VERSION="${{ steps.versions.outputs.debian_version }}"
+          PRERELEASE_TAG="${{ steps.versions.outputs.prerelease_tag }}"
+          STABLE_TAG="${{ steps.versions.outputs.stable_tag }}"
           echo "=== Main Branch CI/CD Complete ==="
-          echo "Package version: ${VERSION}"
-          echo "Release tag: v${TAG_VERSION}"
-          echo "Release URL: https://github.com/${{ github.repository }}/releases/tag/v${TAG_VERSION}"
+          echo "Debian package version: ${DEBIAN_VERSION}"
+          echo "Pre-release tag: ${PRERELEASE_TAG}"
+          echo "Stable tag (draft): ${STABLE_TAG}"
+          echo "Pre-release URL: https://github.com/${{ github.repository }}/releases/tag/${PRERELEASE_TAG}"
+          echo "Draft URL: https://github.com/${{ github.repository }}/releases/tag/${STABLE_TAG}"
           echo ""
-          echo "✅ Pre-release created"
-          echo "✅ Draft release created"
+          echo "✅ Pre-release created with .deb package"
+          echo "✅ Draft release created with .deb attached"
           echo "✅ Dispatched to apt.hatlabs.fi unstable channel"
+          echo ""
+          echo "📝 To publish stable release:"
+          echo "   1. Test the unstable package"
+          echo "   2. Publish the draft release in GitHub UI"
+          echo "   3. release.yml will dispatch to stable channel"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,83 @@
+name: Release Published
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+env:
+  APT_DISTRO: ${{ vars.APT_DISTRO || 'trixie' }}
+  APT_COMPONENT: ${{ vars.APT_COMPONENT || 'hatlabs' }}
+
+jobs:
+  dispatch-to-apt:
+    runs-on: ubuntu-latest
+    # Only handle stable releases - pre-releases are handled by main.yml
+    if: ${{ github.event.release.prerelease == false }}
+    steps:
+      - name: Extract version info from tag
+        id: version
+        run: |
+          STABLE_TAG="${{ github.event.release.tag_name }}"
+          echo "stable_tag=$STABLE_TAG" >> $GITHUB_OUTPUT
+
+          # Extract upstream and revision from stable tag (v5.0.0+2 -> 5.0.0 and 2)
+          if [[ $STABLE_TAG =~ ^v([0-9]+\.[0-9]+\.[0-9]+)\+([0-9]+)$ ]]; then
+            UPSTREAM="${BASH_REMATCH[1]}"
+            REVISION="${BASH_REMATCH[2]}"
+
+            echo "upstream=$UPSTREAM" >> $GITHUB_OUTPUT
+            echo "revision=$REVISION" >> $GITHUB_OUTPUT
+
+            echo "Stable tag: $STABLE_TAG"
+            echo "Upstream: $UPSTREAM"
+            echo "Revision: $REVISION"
+          else
+            echo "Error: Tag format invalid. Expected: v{version}+{N}"
+            echo "Got: $STABLE_TAG"
+            exit 1
+          fi
+
+      - name: Verify release has assets
+        run: |
+          STABLE_TAG="${{ steps.version.outputs.stable_tag }}"
+          ASSET_COUNT=$(gh release view "$STABLE_TAG" --repo ${{ github.repository }} --json assets --jq '.assets | length')
+
+          if [ "$ASSET_COUNT" -eq 0 ]; then
+            echo "❌ Error: Release has no assets attached"
+            echo "The .deb package should have been attached when the draft was created"
+            exit 1
+          fi
+
+          echo "✅ Release has $ASSET_COUNT asset(s)"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Trigger APT repository
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.APT_REPO_PAT }}
+          repository: hatlabs/apt.hatlabs.fi
+          event-type: package-updated
+          client-payload: |
+            {
+              "repository": "${{ github.repository }}",
+              "distro": "${{ env.APT_DISTRO }}",
+              "channel": "stable",
+              "component": "${{ env.APT_COMPONENT }}"
+            }
+
+      - name: Report success
+        run: |
+          STABLE_TAG="${{ steps.version.outputs.stable_tag }}"
+          UPSTREAM="${{ steps.version.outputs.upstream }}"
+          REVISION="${{ steps.version.outputs.revision }}"
+
+          echo "=== Stable Release Published ==="
+          echo "Stable tag: $STABLE_TAG"
+          echo "Debian version: ${UPSTREAM}-${REVISION}"
+          echo "Release URL: https://github.com/${{ github.repository }}/releases/tag/$STABLE_TAG"
+          echo ""
+          echo "✅ Dispatched to apt.hatlabs.fi stable channel"


### PR DESCRIPTION
## Summary

- Adapts the standardized pr-main-release workflow pattern from cockpit-apt
- Updates build-deb action to use cargo-deb instead of dpkg-buildpackage (fixes broken build)
- Adds calculate-revision.sh script for version management
- Creates new release.yml for stable release handling

## Changes

**Version scheme:**
- Pre-release tags: `v{version}+{N}_pre`
- Stable tags: `v{version}+{N}`
- Debian versions: `{version}-{N}`

**Workflow behavior:**
- `main.yml`: On push to main, creates pre-release with assets attached, creates draft stable release
- `release.yml`: On release publish, verifies assets exist, dispatches to APT stable channel

## Test plan

- [ ] Verify workflows pass lint checks
- [ ] Test by pushing to main branch
- [ ] Verify pre-release is created with .deb attached
- [ ] Verify draft stable release is created
- [ ] Test publishing draft to trigger stable channel dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)