### PR TITLE
fix(ci): make generate-changelog.sh a no-op for cargo-deb

### DIFF
--- a/.github/scripts/generate-changelog.sh
+++ b/.github/scripts/generate-changelog.sh
@@ -1,81 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
-# Generate debian/changelog dynamically for CI builds
-# Usage: generate-changelog.sh --upstream <version> --revision <N>
+# No-op for cargo-deb projects
+# cargo-deb gets all package metadata from Cargo.toml, not debian/changelog
+# This script exists to satisfy the shared-workflow's check for a local override
 
-UPSTREAM=""
-REVISION=""
-
-while [[ $# -gt 0 ]]; do
-    case $1 in
-        --upstream)
-            UPSTREAM="$2"
-            shift 2
-            ;;
-        --revision)
-            REVISION="$2"
-            shift 2
-            ;;
-        *)
-            echo "Error: Unknown option $1" >&2
-            echo "Usage: $0 --upstream <version> --revision <N>" >&2
-            exit 1
-            ;;
-    esac
-done
-
-if [ -z "$UPSTREAM" ] || [ -z "$REVISION" ]; then
-    echo "Error: Both --upstream and --revision are required" >&2
-    echo "Usage: $0 --upstream <version> --revision <N>" >&2
-    exit 1
-fi
-
-# Package name
-PACKAGE_NAME="halpi2-rust-daemon"
-
-# Debian version format: upstream-revision
-DEBIAN_VERSION="${UPSTREAM}-${REVISION}"
-
-# Distribution (unstable for CI builds)
-DISTRIBUTION="unstable"
-
-# Urgency
-URGENCY="medium"
-
-# Maintainer information
-MAINTAINER_NAME="${MAINTAINER_NAME:-Hat Labs}"
-MAINTAINER_EMAIL="${MAINTAINER_EMAIL:-info@hatlabs.fi}"
-
-# Date in RFC 2822 format
-DATE=$(date -R)
-
-# Get recent changes from git log
-# Get commits since last published release tag
-LAST_TAG=$(git tag -l "v*" --sort=-version:refname | grep -v "_pre" | head -n1 || echo "")
-
-if [ -n "$LAST_TAG" ]; then
-    CHANGES=$(git log "${LAST_TAG}"..HEAD --pretty=format:"  * %s" --no-merges || echo "  * Build ${REVISION}")
-else
-    # No previous tags, use recent commits
-    CHANGES=$(git log -10 --pretty=format:"  * %s" --no-merges || echo "  * Build ${REVISION}")
-fi
-
-# If no changes (shouldn't happen), use a default message
-if [ -z "$CHANGES" ]; then
-    CHANGES="  * Build ${REVISION}"
-fi
-
-# Generate debian/changelog entry
-cat > debian/changelog <<EOF
-${PACKAGE_NAME} (${DEBIAN_VERSION}) ${DISTRIBUTION}; urgency=${URGENCY}
-
-${CHANGES}
-
- -- ${MAINTAINER_NAME} <${MAINTAINER_EMAIL}>  ${DATE}
-EOF
-
-echo "Generated debian/changelog:"
-echo "  Version: ${DEBIAN_VERSION}"
-echo "  Distribution: ${DISTRIBUTION}"
-cat debian/changelog
+echo "Skipping debian/changelog generation (cargo-deb project)"
+echo "Package metadata is sourced from Cargo.toml"


### PR DESCRIPTION
## Summary

- Make `generate-changelog.sh` a no-op for cargo-deb projects

## Problem

The build failed because the script tried to write to `debian/changelog`, but cargo-deb projects don't have a `debian/` directory - they get all package metadata from `Cargo.toml`.

## Solution

Replace the script with a no-op that just logs a message. The shared-workflow checks for a local `generate-changelog.sh` script and calls it if present. For cargo-deb projects, we just need it to exit successfully without trying to create `debian/changelog`.

## Test plan

- [ ] PR checks pass
- [ ] After merge, main branch CI/CD builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)