### PR TITLE
fix(ci): add --no-strip to cargo-deb for cross-compilation

### DIFF
--- a/.github/actions/build-deb/action.yml
+++ b/.github/actions/build-deb/action.yml
@@ -29,8 +29,8 @@ runs:
         # Build the halpi CLI tool as well (referenced in Cargo.toml assets)
         cargo build --release --target aarch64-unknown-linux-musl -p halpi
 
-        # Build the .deb package
-        cargo deb -p halpid --target aarch64-unknown-linux-musl --no-build
+        # Build the .deb package (--no-strip because host strip can't handle ARM64 binaries)
+        cargo deb -p halpid --target aarch64-unknown-linux-musl --no-build --no-strip
       shell: bash
 
     - name: Move package to root


### PR DESCRIPTION
## Summary

- Add `--no-strip` flag to `cargo deb` for cross-compilation

## Problem

The build failed with:
```
strip: Unable to recognise the format of the input file
error: Unable to strip binary
```

The host's `strip` command (x86_64) cannot process ARM64 binaries when cross-compiling.

## Solution

Add `--no-strip` flag to skip stripping during `cargo deb`. The binaries are already optimized for release, and stripping is not essential.

## Test plan

- [ ] PR checks pass
- [ ] After merge, main branch CI/CD builds successfully and creates releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)