### PR TITLE
fix(ci): correct architecture in rename-packages.sh to arm64

### DIFF
--- a/.github/scripts/rename-packages.sh
+++ b/.github/scripts/rename-packages.sh
@@ -37,9 +37,9 @@ if [ -z "$VERSION" ] || [ -z "$DISTRO" ] || [ -z "$COMPONENT" ]; then
     exit 1
 fi
 
-# Package name and architecture
+# Package name and architecture (ARM64 for Raspberry Pi)
 PACKAGE_NAME="halpi2-rust-daemon"
-ARCH="amd64"
+ARCH="arm64"
 
 OLD_NAME="${PACKAGE_NAME}_${VERSION}_${ARCH}.deb"
 NEW_NAME="${PACKAGE_NAME}_${VERSION}_${ARCH}+${DISTRO}+${COMPONENT}.deb"


### PR DESCRIPTION
## Summary

- Fix architecture from `amd64` to `arm64` in rename-packages.sh

## Problem

The build failed because `rename-packages.sh` was looking for `*_amd64.deb` but the actual package is `*_arm64.deb` (built for Raspberry Pi).

## Solution

Change `ARCH="amd64"` to `ARCH="arm64"` on line 42.

## Test plan

- [ ] PR checks pass
- [ ] After merge, main branch CI/CD builds successfully and creates releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)