### PR TITLE
fix(ci): handle cargo-deb version format in rename script

### DIFF
--- a/.github/scripts/rename-packages.sh
+++ b/.github/scripts/rename-packages.sh
@@ -41,7 +41,14 @@ fi
 PACKAGE_NAME="halpi2-rust-daemon"
 ARCH="arm64"
 
-OLD_NAME="${PACKAGE_NAME}_${VERSION}_${ARCH}.deb"
+# cargo-deb uses the upstream version from Cargo.toml, not the full Debian version
+# Debian version format: <upstream>-<revision> (e.g., 5.0.0-2)
+# cargo-deb produces: <upstream> (e.g., 5.0.0)
+UPSTREAM_VERSION="${VERSION%-*}"  # Strip -N revision suffix
+
+# cargo-deb produced package (uses upstream version only)
+OLD_NAME="${PACKAGE_NAME}_${UPSTREAM_VERSION}_${ARCH}.deb"
+# Final package name (uses full Debian version with revision)
 NEW_NAME="${PACKAGE_NAME}_${VERSION}_${ARCH}+${DISTRO}+${COMPONENT}.deb"
 
 if [ -f "$OLD_NAME" ]; then


### PR DESCRIPTION
## Summary

Fix the package rename script to handle cargo-deb's version format.

## Problem

- The shared workflow passes Debian version `5.0.0-2` (upstream-revision)
- cargo-deb produces packages with upstream version only: `halpi2-rust-daemon_5.0.0_arm64.deb`
- The script was looking for `halpi2-rust-daemon_5.0.0-2_arm64.deb` which doesn't exist

## Solution

Extract the upstream version from the Debian version (`5.0.0-2` → `5.0.0`) to find the cargo-deb produced package, then rename it with the full Debian version for the APT repository.

## Test plan

- [ ] CI passes - package should be found and renamed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)