### PR TITLE
fix(ci): account for cargo-deb's -1 default revision

### DIFF
--- a/.github/scripts/rename-packages.sh
+++ b/.github/scripts/rename-packages.sh
@@ -41,13 +41,13 @@ fi
 PACKAGE_NAME="halpi2-rust-daemon"
 ARCH="arm64"
 
-# cargo-deb uses the upstream version from Cargo.toml, not the full Debian version
+# cargo-deb uses the upstream version from Cargo.toml + default revision -1
 # Debian version format: <upstream>-<revision> (e.g., 5.0.0-2)
-# cargo-deb produces: <upstream> (e.g., 5.0.0)
+# cargo-deb produces: <upstream>-1 (e.g., 5.0.0-1, always uses -1 as revision)
 UPSTREAM_VERSION="${VERSION%-*}"  # Strip -N revision suffix
 
-# cargo-deb produced package (uses upstream version only)
-OLD_NAME="${PACKAGE_NAME}_${UPSTREAM_VERSION}_${ARCH}.deb"
+# cargo-deb produced package (uses upstream version with -1 default revision)
+OLD_NAME="${PACKAGE_NAME}_${UPSTREAM_VERSION}-1_${ARCH}.deb"
 # Final package name (uses full Debian version with revision)
 NEW_NAME="${PACKAGE_NAME}_${VERSION}_${ARCH}+${DISTRO}+${COMPONENT}.deb"
 


### PR DESCRIPTION
## Summary

Fix the package rename script to handle cargo-deb's default `-1` revision suffix.

## Problem

cargo-deb produces packages with `-1` as the default Debian revision:
```
halpi2-rust-daemon_5.0.0-1_arm64.deb
```

The script was looking for `halpi2-rust-daemon_5.0.0_arm64.deb` (without the `-1`).

## Solution

Update the script to look for the cargo-deb format with `-1` suffix:
```bash
OLD_NAME="${PACKAGE_NAME}_${UPSTREAM_VERSION}-1_${ARCH}.deb"
```

This will find `halpi2-rust-daemon_5.0.0-1_arm64.deb` and rename it to `halpi2-rust-daemon_5.0.0-3_arm64+trixie+hatlabs.deb`.

## Test plan

- [ ] CI passes - package should be found and renamed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)