### PR TITLE
fix(ci): pass correct Debian version to cargo-deb

### DIFF
--- a/.github/actions/build-deb/action.yml
+++ b/.github/actions/build-deb/action.yml
@@ -29,8 +29,18 @@ runs:
         # Build the halpi CLI tool as well (referenced in Cargo.toml assets)
         cargo build --release --target aarch64-unknown-linux-musl -p halpi
 
+        # Read Debian version from file (written by generate-changelog.sh)
+        if [ -f ".debian-version" ]; then
+          DEB_VERSION=$(cat .debian-version)
+          echo "Using Debian version from .debian-version: $DEB_VERSION"
+          VERSION_FLAG="--deb-version=$DEB_VERSION"
+        else
+          echo "No .debian-version file found, using Cargo.toml version"
+          VERSION_FLAG=""
+        fi
+
         # Build the .deb package (--no-strip because host strip can't handle ARM64 binaries)
-        cargo deb -p halpid --target aarch64-unknown-linux-musl --no-build --no-strip
+        cargo deb -p halpid --target aarch64-unknown-linux-musl --no-build --no-strip $VERSION_FLAG
       shell: bash
 
     - name: Move package to root

--- a/.github/scripts/generate-changelog.sh
+++ b/.github/scripts/generate-changelog.sh
@@ -1,9 +1,39 @@
 #!/bin/bash
 set -euo pipefail
 
-# No-op for cargo-deb projects
-# cargo-deb gets all package metadata from Cargo.toml, not debian/changelog
-# This script exists to satisfy the shared-workflow's check for a local override
+# Generate version file for cargo-deb
+# cargo-deb gets package metadata from Cargo.toml, but we need to override
+# the version to include the calculated revision number
+
+UPSTREAM=""
+REVISION=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --upstream)
+            UPSTREAM="$2"
+            shift 2
+            ;;
+        --revision)
+            REVISION="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$UPSTREAM" ] || [ -z "$REVISION" ]; then
+    echo "Error: --upstream and --revision are required" >&2
+    exit 1
+fi
+
+DEBIAN_VERSION="${UPSTREAM}-${REVISION}"
 
 echo "Skipping debian/changelog generation (cargo-deb project)"
-echo "Package metadata is sourced from Cargo.toml"
+echo "Writing Debian version to .debian-version: $DEBIAN_VERSION"
+
+# Write version file for build-deb action to read
+echo "$DEBIAN_VERSION" > .debian-version

--- a/.github/scripts/rename-packages.sh
+++ b/.github/scripts/rename-packages.sh
@@ -41,14 +41,10 @@ fi
 PACKAGE_NAME="halpi2-rust-daemon"
 ARCH="arm64"
 
-# cargo-deb uses the upstream version from Cargo.toml + default revision -1
-# Debian version format: <upstream>-<revision> (e.g., 5.0.0-2)
-# cargo-deb produces: <upstream>-1 (e.g., 5.0.0-1, always uses -1 as revision)
-UPSTREAM_VERSION="${VERSION%-*}"  # Strip -N revision suffix
-
-# cargo-deb produced package (uses upstream version with -1 default revision)
-OLD_NAME="${PACKAGE_NAME}_${UPSTREAM_VERSION}-1_${ARCH}.deb"
-# Final package name (uses full Debian version with revision)
+# cargo-deb now receives the correct Debian version via --deb-version
+# The package is built with the full version (e.g., 5.0.0-3)
+OLD_NAME="${PACKAGE_NAME}_${VERSION}_${ARCH}.deb"
+# Add distro+component suffix for APT repository
 NEW_NAME="${PACKAGE_NAME}_${VERSION}_${ARCH}+${DISTRO}+${COMPONENT}.deb"
 
 if [ -f "$OLD_NAME" ]; then


### PR DESCRIPTION
## Summary

Fix cargo-deb to use the correct Debian version with the calculated revision number, not the default `-1`.

## Problem

cargo-deb defaults to `-1` as the Debian revision, producing packages like `halpi2-rust-daemon_5.0.0-1_arm64.deb`. But the APT repository expects the calculated revision (e.g., `5.0.0-3`), and the package's internal metadata must match.

## Solution

1. **generate-changelog.sh**: Parse `--upstream` and `--revision` args, write full Debian version to `.debian-version` file
2. **build-deb action**: Read `.debian-version` and pass `--deb-version` flag to cargo-deb
3. **rename-packages.sh**: Simplified - now looks for package with correct version directly

## Flow

```
generate-changelog.sh --upstream 5.0.0 --revision 3
  → writes "5.0.0-3" to .debian-version

build-deb action
  → reads .debian-version
  → runs: cargo deb --deb-version=5.0.0-3
  → produces: halpi2-rust-daemon_5.0.0-3_arm64.deb

rename-packages.sh --version 5.0.0-3
  → finds halpi2-rust-daemon_5.0.0-3_arm64.deb
  → renames to halpi2-rust-daemon_5.0.0-3_arm64+trixie+hatlabs.deb
```

## Test plan

- [ ] CI passes - package built with correct version in metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)