### PR TITLE
fix(ci): set apt-distro to 'any' for all distributions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ jobs:
     with:
       package-name: halpi2-rust-daemon
       package-description: 'HALPI2 hardware daemon (Rust implementation)'
+      apt-distro: any
       apt-component: hatlabs
     secrets:
       APT_REPO_PAT: ${{ secrets.APT_REPO_PAT }}


### PR DESCRIPTION
## Summary

Set `apt-distro: any` to deploy the Rust daemon to all distributions.

## Rationale

The Rust daemon is a statically-linked musl binary that works on any distribution. Setting `apt-distro: any` makes it available for both legacy (bookworm) and current (trixie) distributions.

## Change

```yaml
apt-distro: any
```

## Test plan

- [ ] CI passes
- [ ] Package deploys to APT repository for all distributions

🤖 Generated with [Claude Code](https://claude.com/claude-code)