### PR TITLE
fix(ci): add apt-distro to release.yml for stable releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ jobs:
   publish:
     uses: hatlabs/shared-workflows/.github/workflows/publish-stable.yml@main
     with:
+      apt-distro: any
       apt-component: hatlabs
     secrets:
       APT_REPO_PAT: ${{ secrets.APT_REPO_PAT }}


### PR DESCRIPTION
## Summary
- Add `apt-distro: any` to release.yml workflow
- This was missing, causing stable releases to use default `trixie` instead of `any`
- Fixes stable release deployment to only deploy to trixie-stable instead of all distributions

## Root Cause
The `release.yml` workflow calls `publish-stable.yml` but was not passing `apt-distro`. The shared workflow defaults to `trixie`, so stable releases were incorrectly deployed only to `trixie-stable` instead of all distributions (bookworm, trixie, forky) and the legacy `stable/main`.

PR #86 fixed `main.yml` (for pre-releases) but missed `release.yml` (for stable releases).

## Test plan
- [x] Verify workflow syntax is correct
- [ ] Merge and create new stable release to verify deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)