### PR TITLE
feat: add lefthook pre-commit hooks for format/lint checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,29 @@ cargo clippy --all-targets -- -D warnings
 cargo doc --no-deps --open
 ```
 
+### Pre-commit Hooks
+
+This project uses [lefthook](https://github.com/evilmartians/lefthook) for pre-commit hooks to run format and lint checks locally before commits.
+
+```bash
+# Install lefthook (one-time)
+brew install lefthook
+
+# Enable hooks in this repo
+./run hooks-install
+```
+
+**What it checks:**
+
+- `cargo fmt --all -- --check` - Code formatting
+- `cargo clippy --all-targets -- -D warnings` - Linting
+
+**Skip hooks when needed:**
+
+```bash
+git commit --no-verify -m "WIP: message"
+```
+
 ## Migrating from Python halpid 4.x
 
 The Rust daemon is 100% API compatible with Python `halpid` 4.x. Migration is straightforward:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,12 @@
+pre-commit:
+  parallel: true
+  commands:
+    rust-fmt-check:
+      glob: "*.rs"
+      run: cargo fmt --all -- --check
+      fail_text: "Run 'cargo fmt --all' to fix formatting."
+
+    rust-clippy:
+      glob: "*.rs"
+      run: cargo clippy --all-targets -- -D warnings
+      fail_text: "Fix clippy warnings before committing."

--- a/run
+++ b/run
@@ -350,6 +350,27 @@ function build-release {
   echo "✅ Release artifacts built in target/aarch64-unknown-linux-musl/release/"
 }
 
+function hooks-install {
+  #@ Install pre-commit hooks using lefthook
+  #@ Category: Development Utilities
+  if ! command -v lefthook &> /dev/null; then
+    echo "Error: lefthook not found. Install with: brew install lefthook"
+    exit 1
+  fi
+  lefthook install
+  echo "✅ Pre-commit hooks installed"
+}
+
+function hooks-run {
+  #@ Run pre-commit hooks manually
+  #@ Category: Development Utilities
+  if ! command -v lefthook &> /dev/null; then
+    echo "Error: lefthook not found. Install with: brew install lefthook"
+    exit 1
+  fi
+  lefthook run pre-commit
+}
+
 ################################################################################
 # CI/CD Commands
 


### PR DESCRIPTION
## Summary

- Add lefthook.yml with cargo fmt and clippy checks
- Add hooks-install command to run script  
- Update README with developer setup instructions

## Test plan

- [x] Tested `lefthook run pre-commit` locally
- [x] Verified run script `hooks-install` command works
- [x] Confirmed hooks run on commit

## Developer Setup

After merging, developers should:
```bash
brew install lefthook
./run hooks-install
```

Fixes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)