### PR TITLE
refactor: remove docker-build function that produces host-arch binaries

### DIFF
--- a/run
+++ b/run
@@ -129,30 +129,6 @@ _detect_docker_platform() {
   esac
 }
 
-function docker-build {
-  #@ Build in Docker container (automatic Linux environment)
-  #@ Usage: docker-build [--release]
-  #@ Category: Docker Build
-  local build_args="$@"
-
-  echo "🏗️  Building in Docker container..."
-
-  # Detect host architecture for platform selection
-  IFS=':' read -r platform _ <<< "$(_detect_docker_platform)"
-
-  docker run --rm \
-    --platform "$platform" \
-    -v "$(pwd):/workspace" \
-    -w /workspace \
-    mcr.microsoft.com/devcontainers/rust:1-bookworm \
-    bash -c "
-      set -e
-      echo '🔨 Running cargo build $build_args...'
-      cargo build $build_args
-      echo '✅ Build complete!'
-    " && echo "✅ Build successful in Docker container"
-}
-
 function docker-cross-build {
   #@ Cross-compile for ARM64 Linux using cross in Docker
   #@ Usage: docker-cross-build [--release]


### PR DESCRIPTION
## Summary
Remove the `docker-build` function that builds binaries for the host architecture (x86_64 on most dev machines). These binaries are useless for HALPI2 since it only runs on ARM64.

## What remains
- `docker-cross-build` - Cross-compiles to ARM64 (correct)
- `docker-build-deb` - Builds ARM64 Debian packages (correct)
- `_detect_docker_platform` - Used by above functions to run Docker containers on the correct host platform

## Context
HALPI2 is a Raspberry Pi CM5 based device. It's impossible to run the daemon on amd64, so building host-architecture binaries is counterproductive and confusing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)