### PR TITLE
feat(halpi): show device_id in status output

### DIFF
--- a/halpi/src/commands/status.rs
+++ b/halpi/src/commands/status.rs
@@ -31,6 +31,7 @@ fn print_status_table(values: &HashMap<String, Value>) {
         &get_value_str(values, "firmware_version"),
         "",
     );
+    print_row("device_id", &get_value_str(values, "device_id"), "");
     println!();
 
     // State and outputs
@@ -93,9 +94,9 @@ fn print_status_table(values: &HashMap<String, Value>) {
 /// Print a formatted table row
 fn print_row(key: &str, value: &str, unit: &str) {
     if unit.is_empty() {
-        println!("{:<24} {:>15}", key, value);
+        println!("{:<24} {:>16}", key, value);
     } else {
-        println!("{:<24} {:>15} {}", key, value, unit);
+        println!("{:<24} {:>16} {}", key, value, unit);
     }
 }
 


### PR DESCRIPTION
## Why

The HALPI2 device unique ID is exposed by `halpid` on the Unix socket (`GET /values/device_id`), but the `halpi` CLI had no way to display it. Users wanting to retrieve it had to bypass the CLI and curl the daemon socket directly.

## What

Add a `device_id` row to `halpi status`, placed in the version block immediately after `firmware_version` since it identifies the device alongside hardware/firmware version.

The value column is widened from 15 to 16 chars to fit the 16-char lowercase hex ID without breaking alignment of the rest of the table.

## Example

```
hardware_version                          2.0.0
firmware_version                          2.1.0
device_id                      e66164840bce7521

state                          OperationalCoOp
...
```

## Test plan

- [x] `cargo fmt -p halpi --check` passes
- [x] `cargo clippy -p halpi --all-targets -- -D warnings` clean
- [x] `cargo test -p halpi` — 19/19 pass
- [ ] Field test on `pi@halos.local` after deploy